### PR TITLE
Author name was not properly display.

### DIFF
--- a/reva-cli/main.go
+++ b/reva-cli/main.go
@@ -12,7 +12,7 @@ func main() {
 	app := cli.NewApp()
 	app.Authors = []cli.Author{
 		cli.Author{
-			Name:  "Hugo GonzÃÂÃÂÃÂÃÂ¡lez Labrador",
+			Name:  "Hugo Gonzalez Labrador",
 			Email: "contact@hugo.labkode.com",
 		},
 	}


### PR DESCRIPTION
If one runs reva-cli --help it displays:

[---some skipped text---]

VERSION:
   0.1.0

AUTHOR:
   Hugo GonzÃÂÃÂÃÂÃÂ¡lez Labrador <contact@hugo.labkode.com>

[--- more text output ---]


![image](https://user-images.githubusercontent.com/5689472/63151939-f094cb80-c00a-11e9-96d8-e42c7a0edfd9.png)
