### PR TITLE
Fix oo

### DIFF
--- a/ocproxy/api/templates.go
+++ b/ocproxy/api/templates.go
@@ -37,6 +37,7 @@ var publicLinkTemplate string = `
 		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/files/css/upload.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/cernbox-theme/core/css/styles.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/wopiviewer/css/style.css">
+    		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/collabora/css/style.css">
 			<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/main.css">
 			<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/editor.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/gallery/css/slideshow.css">
@@ -148,6 +149,7 @@ var publicLinkTemplate string = `
 		})(jQuery, OC);
 		</script>
 		<script src="{{ .BaseUrl }}/apps/wopiviewer/js/script.js"></script>
+		<script src="{{ .BaseUrl }}/apps/collabora/js/script.js"></script>
 		<script src="{{ .BaseUrl }}/apps/onlyoffice/js/main.js"></script>
 		<script src="{{ .BaseUrl }}/apps/onlyoffice/js/editor.js"></script>
 		<script src="{{ .BaseUrl }}/apps/files_pdfviewer/js/previewplugin.js"></script>
@@ -320,6 +322,7 @@ var publicLinkTemplatePassword = `
     <link rel="stylesheet" href="{{ .BaseUrl }}/core/css/jquery.ocdialog.css">
     <link rel="stylesheet" href="{{ .BaseUrl }}/apps/files_sharing/css/authenticate.css">
 	<link rel="stylesheet" href="{{ .BaseUrl }}/apps/wopiviewer/css/style.css">
+	<link rel="stylesheet" href="{{ .BaseUrl }}/apps/collabora/css/style.css">
 	<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/main.css">
 	<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/editor.css">
     <script src="{{ .BaseUrl }}/index.php/core/js/oc.js"></script>
@@ -371,6 +374,7 @@ var publicLinkTemplatePassword = `
     <script src="{{ .BaseUrl }}/core/js/files/client.js"></script>
     <script src="{{ .BaseUrl }}/apps/files_sharing/js/authenticate.js"></script>
     <script src="{{ .BaseUrl }}/apps/wopiviewer/js/script.js"></script>
+    <script src="{{ .BaseUrl }}/apps/collabora/js/script.js"></script>
 	<script src="{{ .BaseUrl }}/apps/onlyoffice/js/main.js"></script>
 	<script src="{{ .BaseUrl }}/apps/onlyoffice/js/editor.js"></script>
   </head>
@@ -577,6 +581,7 @@ var publicLinkTemplateFile = `
 		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/files/css/upload.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/cernbox-theme/core/css/styles.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/wopiviewer/css/style.css">
+    		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/collabora/css/style.css">
 			<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/main.css">
 			<link rel="stylesheet" href="{{ .BaseUrl }}/apps/onlyoffice/css/editor.css">
     		<link rel="stylesheet" href="{{ .BaseUrl }}/apps/files_pdfviewer/css/style.css">
@@ -676,6 +681,7 @@ var publicLinkTemplateFile = `
 		})(jQuery, OC);
 		</script>
     	<script src="{{ .BaseUrl }}/apps/wopiviewer/js/script.js"></script>
+    	<script src="{{ .BaseUrl }}/apps/collabora/js/script.js"></script>
 		<script src="{{ .BaseUrl }}/apps/files_pdfviewer/js/previewplugin.js"></script>
 		<script src="{{ .BaseUrl }}/apps/onlyoffice/js/main.js"></script>
 		<script src="{{ .BaseUrl }}/apps/onlyoffice/js/editor.js"></script>

--- a/ocproxy/ocproxy.spec
+++ b/ocproxy/ocproxy.spec
@@ -4,7 +4,7 @@
 
 Name: ocproxy
 Summary: ownCloud Proxy
-Version: 0.0.63
+Version: 0.0.64
 Release: 1%{?dist}
 License: AGPLv3
 BuildRoot: %{_tmppath}/%{name}-buildroot
@@ -54,6 +54,9 @@ rm -rf %buildroot/
 
 
 %changelog
+* Tue Jun 02 2020 Diogo Castro <diogo.castro@cern.ch> 0.0.64
+- ocproxy: use versions folder id for OO instead of real id
+- ocproxy: add collabora to public links
 * Tue May 26 2020 Ishank Arora <ishank.arora@cern.ch> 0.0.63
 - Read stime from EOS instead of mtime, correct quota info
 * Mon May 18 2020 Diogo Castro <diogo.castro@cern.ch> 0.0.62


### PR DESCRIPTION
This PR changes the OO id to the one of the .sys folder. This way, we don't get hit by the problem of versions being created and users landing on different documents.

Still to be resolved is a race condition where multiple users save at the same time. This might cause one of the users to receive a warning that a conflict was detected. I was going to put a fix on ocproxy, but Giuseppe agreed to do it on wopi side. So I think we can merge this and push it to canary.