### PR TITLE
Fix corruption conflict

### DIFF
--- a/ocproxy/api/api.go
+++ b/ocproxy/api/api.go
@@ -742,9 +742,9 @@ func (p *proxy) onlyOfficeTrackInternal(w http.ResponseWriter, r *http.Request, 
 
 		// If the save was called after the file being closed, unlock.
 		// Otherwise, refresh the lock
-		if req.Status == trackerStatusMustSave || req.Status == trackerStatusCorrupted || req.Status == trackerStatusForceSavingError {
+		if req.Status == trackerStatusMustSave || req.Status == trackerStatusForceSavingError {
 			p.unlockWopi(ctx, revaPath)
-		} else { // req.Status == trackerStatusEditingMustSave
+		} else { // req.Status == trackerStatusEditingMustSave || req.Status == trackerStatusCorrupted
 			succeeded, _ := p.lockWopi(md)
 			if !succeeded {
 				w.WriteHeader(http.StatusBadRequest)

--- a/ocproxy/ocproxy.spec
+++ b/ocproxy/ocproxy.spec
@@ -4,7 +4,7 @@
 
 Name: ocproxy
 Summary: ownCloud Proxy
-Version: 0.0.78
+Version: 0.0.79
 Release: 1%{?dist}
 License: AGPLv3
 BuildRoot: %{_tmppath}/%{name}-buildroot
@@ -54,6 +54,8 @@ rm -rf %buildroot/
 
 
 %changelog
+* Tue Feb 23 2021 Diogo Castro <diogo.castro@cern.ch> 0.0.79
+- Do not unlock the files when receiving saving error status from oo
 * Mon Feb 3 2021 Diogo Castro <diogo.castro@cern.ch> 0.0.78
 - New Canary with OCIS option
 * Mon Feb 3 2021 Diogo Castro <diogo.castro@cern.ch> 0.0.77


### PR DESCRIPTION
We were unlocking files when receiving status 3 (document saving error has occurred) from OO, because we assumed this would be the last notification we would get. But that is not true, we still receive a status 7 (error has occurred while force saving the document) when the user really closes the document, which was creating tons of conflict files. With this PR, this no longer happens.