### PR TITLE
WOPI unlock on document saving error

### DIFF
--- a/ocproxy/api/api.go
+++ b/ocproxy/api/api.go
@@ -742,7 +742,7 @@ func (p *proxy) onlyOfficeTrackInternal(w http.ResponseWriter, r *http.Request, 
 
 		// If the save was called after the file being closed, unlock.
 		// Otherwise, refresh the lock
-		if req.Status == trackerStatusMustSave || req.Status == trackerStatusForceSavingError {
+		if req.Status == trackerStatusMustSave || req.Status == trackerStatusCorrupted {
 			p.unlockWopi(ctx, revaPath)
 		} else { // req.Status == trackerStatusEditingMustSave || req.Status == trackerStatusCorrupted
 			succeeded, _ := p.lockWopi(md)


### PR DESCRIPTION
The file must be unlocked if the [status](https://api.onlyoffice.com/editors/callback#status) is 2 or 3.
With status 6 and 7, editing continues and you need to update the lock.

I think it was a copying error.
This is the cause of the problem. After status 3 the file was no longer opened for editing. The lock was not removed and the old key was sent to the editor.