### PR TITLE
ocproxy: route HEAD requests on the /download endpoint

### DIFF
--- a/ocproxy/api/api.go
+++ b/ocproxy/api/api.go
@@ -154,7 +154,7 @@ func (p *proxy) registerRoutes() {
 
 	// public link routes
 	p.router.HandleFunc("/index.php/s/{token}", p.renderPublicLink).Methods("GET", "POST")
-	p.router.HandleFunc("/index.php/s/{token}/download", p.plAuth(p.downloadArchivePL)).Methods("GET")
+	p.router.HandleFunc("/index.php/s/{token}/download", p.plAuth(p.downloadArchivePL)).Methods("GET", "HEAD")
 	p.router.HandleFunc("/index.php/apps/files_sharing/ajax/publicpreview.php", p.tokenAuth(p.getPublicPreview)).Methods("GET")
 
 	// app routes


### PR DESCRIPTION
This allows fetching metadata (size, content-type, expiration, etc.) from a public link share without the need to download it:

```bash
$ curl -I -L https://demo.owncloud.com/s/zgWp1pkJOnrWnzX/download
HTTP/2 200
content-type: application/pdf
expires: 0
pragma: public
content-length: 6657380
[...]
```

(Internal feature request for reference INC3001203)